### PR TITLE
Added support for safeTransfer in to contract

### DIFF
--- a/test/erc1155-test.ts
+++ b/test/erc1155-test.ts
@@ -66,5 +66,51 @@ describe("ERC 1155 execution", () => {
         await expect(instaFiContract.connect(attacker).executeExternal(callUnits, { value: 0}))
             .to.be.revertedWith('TOKEN_SPEND_NOT_PERMITTED_FOR_SENDER')
     });
+    
+    it("Owner --> Contract: safeTransferFrom works", async () => {
+        const toContractTransferCall = makeCallUnit(
+            erc1155Contract.address, 
+            "safeTransferFrom", 
+            ['address', 'address', 'uint256', 'uint256', 'bytes'], 
+            [await owner.getAddress(), instaFiContract.address, 1, 1, 0],
+            0,
+        );
+        callUnits = [toContractTransferCall];
+
+        expect(await instaFiContract.executeExternal(callUnits, { value: 0}));
+    });
+    
+    it("Contract --> Owner: safeTransferFrom works", async () => {
+        const toContractTransferCall = makeCallUnit(
+            erc1155Contract.address, 
+            "safeTransferFrom", 
+            ['address', 'address', 'uint256', 'uint256', 'bytes'], 
+            [await owner.getAddress(), instaFiContract.address, 1, 1, 0],
+            0,
+        );
+        const fromContractTransferCall = makeCallUnit(
+            erc1155Contract.address, 
+            "safeTransferFrom", 
+            ['address', 'address', 'uint256', 'uint256', 'bytes'], 
+            [instaFiContract.address, await owner.getAddress(), 1, 1, 0],
+            0,
+        );
+        callUnits = [toContractTransferCall, fromContractTransferCall];
+
+        expect(await instaFiContract.executeExternal(callUnits, { value: 0}));
+    });
+    
+    it("Owner --> Contract: safeBatchTransferFrom works", async () => {
+        const toContractTransferCall = makeCallUnit(
+            erc1155Contract.address, 
+            "safeBatchTransferFrom", 
+            ['address', 'address', 'uint256[]', 'uint256[]', 'bytes'], 
+            [await owner.getAddress(), instaFiContract.address, [1], [1], 0],
+            0,
+        );
+        callUnits = [toContractTransferCall];
+
+        expect(await instaFiContract.executeExternal(callUnits, { value: 0}));
+    });
   
 });

--- a/test/erc721-test.ts
+++ b/test/erc721-test.ts
@@ -130,5 +130,25 @@ describe("ERC 721 execution", () => {
 
         expect(await instaFiContract.executeExternal(callUnits, { value: 0}));
     });
+
+    it("Contract --> Owner: safeTransferFrom works", async () => {
+        const toContractTransferCall = makeCallUnit(
+            erc721Contract.address, 
+            "safeTransferFrom", 
+            ['address', 'address', 'uint256'], 
+            [await owner.getAddress(), instaFiContract.address, 1],
+            0,
+        );
+        const fromContractTransferCall = makeCallUnit(
+            erc721Contract.address, 
+            "safeTransferFrom", 
+            ['address', 'address', 'uint256'], 
+            [instaFiContract.address, await owner.getAddress(), 1],
+            0,
+        );
+        callUnits = [toContractTransferCall, fromContractTransferCall];
+
+        expect(await instaFiContract.executeExternal(callUnits, { value: 0}));
+    });
   
 });


### PR DESCRIPTION
Fixes #4 

This allows us to receive NFTs (ERC721 & ERC1155) - which is essential for integrating NFT minting functionality.

@vinny023  FYI